### PR TITLE
net: renesas: rswitch: implement L3 HW offload

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -9,6 +9,7 @@
 #include <linux/etherdevice.h>
 #include <linux/ethtool.h>
 #include <linux/kernel.h>
+#include <linux/ip.h>
 #include <linux/list.h>
 #include <linux/module.h>
 #include <linux/net_tstamp.h>
@@ -21,8 +22,10 @@
 #include <linux/pm_runtime.h>
 #include <linux/slab.h>
 #include <linux/spinlock.h>
-#include <net/flow_offload.h>
-#include <net/fib_notifier.h>
+#include <net/rtnetlink.h>
+#include <net/nexthop.h>
+#include <net/netns/generic.h>
+#include <net/arp.h>
 
 #include "rswitch_ptp.h"
 #include "rswitch.h"
@@ -773,6 +776,43 @@ enum rswitch_etha_mode {
 #define FWPC0_MACHMA	BIT(27)
 #define FWPC0_VLANSA	BIT(28)
 
+#define LTHSLP0NONE (0)
+#define LTHSLP0v4OTHER (1)
+#define LTHSLP0v4UDP (2)
+#define LTHSLP0v4TCP (3)
+#define LTHSLP0v6 (6)
+//L3 Routing Valid Learn
+#define LTHRVL (BIT(15))
+#define LTHTL (BIT(31))
+#define LTHTS (BIT(31))
+#define LTHTIOG (BIT(0))
+#define LTHTR (BIT(1))
+// L3 Entry Delete
+#define LTHED (BIT(16))
+
+#define MAC_DST_OFFSET (0)
+#define MAC_SRC_OFFSET (6)
+#define IP_VERSION_OFFSET (12)
+#define IPV4_SRC_OFFSET (26)
+#define IPV4_DST_OFFSET (30)
+
+#define FWFOBFV0Ci(i) (FWFOBFV0C0 + ((i) * 0x10))
+#define FWFOBFV1Ci(i) (FWFOBFV1C0 + ((i) * 0x10))
+#define FWFOBFCi(i) (FWFOBFC0 + ((i) * 0x10))
+#define FWCFMCij(i, j) (FWCFMC00 + ((i) * 0x40 + (j) * 0x4))
+#define FWCFCi(i) (FWCFC0 + ((i) * 0x40))
+#define SNOOPING_BUS_OFFSET(offset) ((offset) << 16)
+#define FBFILTER_NUM(i) (2 * (PFL_TWBF_N + PFL_THBF_N + i))
+#define FBFILTER_IDX(i) ((i / 2) - PFL_TWBF_N - PFL_THBF_N)
+
+
+#define MASK_MODE (0)
+#define EXPAND_MODE (BIT(0))
+#define PRECISE_MODE (BIT(1))
+
+#define DISABLE_CASCADE_FILTER (0)
+#define ENABLE_FILTER (BIT(15))
+
 #define FWPC0_DEFAULT	(FWPC0_LTHTA | FWPC0_IP4UE | FWPC0_IP4TE | \
 			 FWPC0_IP4OE | FWPC0_L2SE | FWPC0_IP4EA | \
 			 FWPC0_IPDSA | FWPC0_IPHLA | FWPC0_MACSDA | \
@@ -842,7 +882,8 @@ enum rswitch_serdes_mode {
 #define BANK_1F80                               0x1f80
 #define VR_MII_AN_CTRL                          0x0004
 
-#define NUM_CHAINS_PER_NDEV	2
+#define NUM_CHAINS_PER_NDEV	3
+
 
 static int num_ndev = 3;
 module_param(num_ndev, int, 0644);
@@ -855,6 +896,12 @@ MODULE_PARM_DESC(num_etha_ports, "Number of using ETHA ports");
 static int num_virt_devices = 6;
 module_param(num_virt_devices, int, 0644);
 MODULE_PARM_DESC(num_virt_devices, "Number of virtual interfaces");
+
+struct rswitch_net {
+	struct rswitch_private *priv;
+};
+
+static unsigned int rswitch_net_id;
 
 #define RSWITCH_TIMEOUT_MS	1000
 static int rswitch_reg_wait(void __iomem *addr, u32 offs, u32 mask, u32 expected)
@@ -951,10 +998,9 @@ static bool rswitch_is_chain_rxed(struct rswitch_gwca_chain *c, u8 unexpected)
 	return false;
 }
 
-static bool rswitch_rx(struct net_device *ndev, int *quota)
+static bool rswitch_rx_chain(struct net_device *ndev, int *quota, struct rswitch_gwca_chain *c, bool learn_chain)
 {
 	struct rswitch_device *rdev = netdev_priv(ndev);
-	struct rswitch_gwca_chain *c = rdev->rx_chain;
 	int boguscnt = c->dirty + c->num_ring - c->cur;
 	int entry = c->cur % c->num_ring;
 	struct rswitch_ext_ts_desc *desc = &c->ts_ring[entry];
@@ -973,6 +1019,22 @@ static bool rswitch_rx(struct net_device *ndev, int *quota)
 		if (--boguscnt < 0)
 			break;
 		skb = c->skb[entry];
+
+		if (learn_chain) {
+			struct rswitch_private *priv = rdev->priv;
+			struct iphdr *iphdr;
+			struct ethhdr *ethhdr;
+
+			skb_reset_mac_header(skb);
+			skb_reset_network_header(skb);
+
+			ethhdr = (struct ethhdr*)skb_mac_header(skb);
+			skb_set_network_header(skb, sizeof(*ethhdr));
+
+			iphdr = ip_hdr(skb);
+			rswitch_add_ipv4_forward(priv, be32_to_cpu(iphdr->saddr), be32_to_cpu(iphdr->daddr));
+		}
+
 		c->skb[entry] = NULL;
 		dma_addr = le32_to_cpu(desc->dptrl) | ((__le64)le32_to_cpu(desc->dptrh) << 32);
 		dma_unmap_single(ndev->dev.parent, dma_addr, PKT_BUF_SZ, DMA_FROM_DEVICE);
@@ -1025,6 +1087,24 @@ static bool rswitch_rx(struct net_device *ndev, int *quota)
 	*quota -= limit - (++boguscnt);
 
 	return boguscnt <= 0;
+}
+
+static bool rswitch_rx(struct net_device *ndev, int *quota)
+{
+	struct rswitch_device *rdev = netdev_priv(ndev);
+	struct rswitch_gwca_chain *default_chain = rdev->rx_default_chain;
+	struct rswitch_gwca_chain *learning_chain = rdev->rx_learning_chain;
+	bool res;
+
+	res = rswitch_rx_chain(ndev, quota, default_chain, false);
+
+	if (res)
+		return res;
+
+	if (learning_chain)
+		res = rswitch_rx_chain(ndev, quota, learning_chain, true);
+
+	return res;
 }
 
 static void rswitch_get_timestamp(struct rswitch_private *priv,
@@ -1092,7 +1172,9 @@ retry:
 
 	if (rswitch_rx(ndev, &quota))
 		goto out;
-	else if (rswitch_is_chain_rxed(rdev->rx_chain, DT_FEMPTY))
+	else if (rswitch_is_chain_rxed(rdev->rx_default_chain, DT_FEMPTY))
+		goto retry;
+	else if (rswitch_is_chain_rxed(rdev->rx_learning_chain, DT_FEMPTY))
 		goto retry;
 
 	netif_wake_subqueue(ndev, 0);
@@ -1101,7 +1183,8 @@ retry:
 
 	/* Re-enable RX/TX interrupts */
 	rswitch_enadis_data_irq(priv, rdev->tx_chain->index, true);
-	rswitch_enadis_data_irq(priv, rdev->rx_chain->index, true);
+	rswitch_enadis_data_irq(priv, rdev->rx_default_chain->index, true);
+	rswitch_enadis_data_irq(priv, rdev->rx_learning_chain->index, true);
 	__iowmb();
 
 out:
@@ -1752,12 +1835,14 @@ static int rswitch_open(struct net_device *ndev)
 	netif_start_queue(ndev);
 
 	/* Enable RX */
-	rswitch_modify(rdev->addr, GWTRC0, 0, BIT(rdev->rx_chain->index));
+	rswitch_modify(rdev->addr, GWTRC0, 0, BIT(rdev->rx_default_chain->index));
+	rswitch_modify(rdev->addr, GWTRC0, 0, BIT(rdev->rx_learning_chain->index));
 
 	/* Enable interrupt */
-	pr_debug("%s: tx = %d, rx = %d\n", __func__, rdev->tx_chain->index, rdev->rx_chain->index);
+	pr_debug("%s: tx = %d, rx = %d\n", __func__, rdev->tx_chain->index, rdev->rx_default_chain->index);
 	rswitch_enadis_data_irq(rdev->priv, rdev->tx_chain->index, true);
-	rswitch_enadis_data_irq(rdev->priv, rdev->rx_chain->index, true);
+	rswitch_enadis_data_irq(rdev->priv, rdev->rx_default_chain->index, true);
+	rswitch_enadis_data_irq(rdev->priv, rdev->rx_learning_chain->index, true);
 
 	rswitch_ptp_init(rdev->priv->ptp_priv, RSWITCH_PTP_REG_LAYOUT_S4, RSWITCH_PTP_CLOCK_S4);
 
@@ -1786,6 +1871,87 @@ static int rswitch_stop(struct net_device *ndev)
 
 	return 0;
 };
+
+static u32 rswitch_search_l3fwd(struct l3_ipv4_fwd_param *param)
+{
+	struct rswitch_private *priv = param->priv;
+
+	rs_write32(param->frame_type, priv->addr + FWLTHTS0);
+	rs_write32(0, priv->addr + FWLTHTS1);
+	rs_write32(0, priv->addr + FWLTHTS2);
+	rs_write32(param->src_ip, priv->addr + FWLTHTS3);
+	rs_write32(param->dst_ip, priv->addr + FWLTHTS4);
+
+	rswitch_reg_wait(priv->addr, FWLTHTSR0, LTHTS, 0);
+
+	return (rs_read32(priv->addr + FWLTHTSR0) & BIT(1));
+}
+
+bool is_l3_exist(struct rswitch_private *priv, u32 src_ip, u32 dst_ip)
+{
+	struct l3_ipv4_fwd_param param = {
+		.priv = priv,
+		.src_ip = src_ip,
+		.dst_ip = dst_ip,
+		.frame_type = LTHSLP0v4OTHER,
+	};
+
+	return !rswitch_search_l3fwd(&param);
+}
+
+static struct rswitch_device *get_dev_by_ip(struct rswitch_private *priv, u32 ip_search, bool use_mask)
+{
+	struct in_device *ip;
+	struct in_ifaddr *in;
+	u32 ip_addr, mask;
+	int i;
+
+	for (i = 0; i < RSWITCH_NUM_HW; i++) {
+		ip = priv->rdev[i]->ndev->ip_ptr;
+		if (ip == NULL)
+			continue;
+
+		in = ip->ifa_list;
+		while (in != NULL) {
+			memcpy(&ip_addr, &in->ifa_address, 4);
+			memcpy(&mask, &in->ifa_mask, 4);
+			ip_addr = be32_to_cpu(ip_addr);
+			mask = be32_to_cpu(mask);
+			in = in->ifa_next;
+
+			if (use_mask && (ip_search & mask) == (ip_addr & mask))
+				return priv->rdev[i];
+
+			if (ip_search == ip_addr)
+				return priv->rdev[i];
+		}
+	}
+
+	return NULL;
+}
+
+bool rswitch_use_direct_descriptor(struct rswitch_device *rdev, struct sk_buff *skb)
+{
+	struct rswitch_private *priv = rdev->priv;
+	struct iphdr *iphdr;
+
+	if (rdev->remote_chain < 0)
+		return false;
+
+	if (be16_to_cpu(skb->protocol) == ETH_P_ARP)
+		return true;
+
+	iphdr = ip_hdr(skb);
+	/* Forward via L3 forwarding instead of direct descriptor */
+	if (is_l3_exist(priv, be32_to_cpu(iphdr->saddr), be32_to_cpu(iphdr->daddr)))
+		return false;
+
+	/* If destination is R-Switch interface - forward via L3 */
+	if (get_dev_by_ip(priv, be32_to_cpu(iphdr->daddr), false))
+		return false;
+
+	return true;
+}
 
 static int rswitch_start_xmit(struct sk_buff *skb, struct net_device *ndev)
 {
@@ -1827,7 +1993,7 @@ static int rswitch_start_xmit(struct sk_buff *skb, struct net_device *ndev)
 
 	/* Use direct descriptor if we know remote chain number */
 	/* HACK: GWCA0 Port number (8) is hardcoded */
-	if (rdev->remote_chain >= 0)
+	if (rswitch_use_direct_descriptor(rdev, skb))
 		desc->info1 |= ((u64)rdev->remote_chain << 32) | (8UL << 48) |  BIT(2);
 
 	skb_tx_timestamp(skb);
@@ -1886,7 +2052,6 @@ static int rswitch_setup_tc(struct net_device *ndev, enum tc_setup_type type,
 {
 	struct rswitch_device *rdev = netdev_priv(ndev);
 
-	pr_err("===== >> %s %d", __func__, __LINE__);
 	switch (type) {
 	case TC_SETUP_BLOCK:
 		return flow_block_cb_setup_simple(type_data,
@@ -1982,6 +2147,353 @@ const struct net_device_ops rswitch_netdev_ops = {
 	.ndo_get_port_parent_id = rswitch_port_get_port_parent_id,
 	.ndo_setup_tc           = rswitch_setup_tc,
 //	.ndo_change_mtu = eth_change_mtu,
+};
+
+// Update TTL
+#define L23UTTLUL (BIT(16))
+// Update destination MAC
+#define L23UMDAUL (BIT(17))
+// Update source MAC
+#define L23UMSAUL (BIT(18))
+
+static int rswitch_setup_l23_update(struct l23_update_info *l23_info)
+{
+	u32 update_rule = 0;
+
+	if (l23_info->update_ttl)
+		update_rule |= L23UTTLUL;
+	if (l23_info->update_dst_mac)
+		update_rule |= L23UMDAUL;
+	if (l23_info->update_src_mac)
+		update_rule |= L23UMSAUL;
+
+	rs_write32(l23_info->routing_number | l23_info->routing_port_valid << 16, l23_info->priv->addr + FWL23URL0);
+	rs_write32(l23_info->dst_mac[0] << 8 | l23_info->dst_mac[1] | update_rule, l23_info->priv->addr + FWL23URL1);
+	rs_write32(l23_info->dst_mac[2] << 24 | l23_info->dst_mac[3] << 16 | l23_info->dst_mac[4] << 8 |
+		l23_info->dst_mac[5], l23_info->priv->addr + FWL23URL2);
+	rs_write32(0, l23_info->priv->addr + FWL23URL3);
+
+	return rs_read32(l23_info->priv->addr + FWL23URLR);
+}
+
+static int rswitch_rn_get(struct rswitch_private *priv)
+{
+	int index;
+
+	index = find_first_zero_bit(priv->l23_routing_number, RSWITCH_MAX_NUM_L23);
+	set_bit(index, priv->l23_routing_number);
+
+	return index;
+}
+
+static int rswitch_modify_l3fwd(struct l3_ipv4_fwd_param *param, bool delete)
+{
+	struct rswitch_private *priv = param->priv;
+
+	if (!delete) {
+		if (param->l23_info.update_dst_mac || param->l23_info.update_src_mac ||
+			param->l23_info.update_ttl) {
+			rswitch_setup_l23_update(&param->l23_info);
+		}
+	}
+
+	if (delete)
+		rs_write32(param->frame_type | LTHED, priv->addr + FWLTHTL0);
+	else
+		rs_write32(param->frame_type, priv->addr + FWLTHTL0);
+
+	rs_write32(0, priv->addr + FWLTHTL1);
+	rs_write32(0, priv->addr + FWLTHTL2);
+	rs_write32(param->src_ip, priv->addr + FWLTHTL3);
+	rs_write32(param->dst_ip, priv->addr + FWLTHTL4);
+
+	rs_write32(0, priv->addr + FWLTHTL5);
+	rs_write32(0, priv->addr + FWLTHTL6);
+	rs_write32(param->l23_info.routing_number | LTHRVL | param->slv << 16, priv->addr + FWLTHTL7);
+	if (param->enable_sub_dst)
+		rs_write32(param->csd, priv->addr + FWLTHTL80);
+	else
+		rs_write32(0, priv->addr + FWLTHTL80);
+	rs_write32(param->dv, priv->addr + FWLTHTL9);
+
+	return rswitch_reg_wait(priv->addr, FWLTHTLR, LTHTL, 0);
+}
+
+static int rswitch_add_l3fwd(struct l3_ipv4_fwd_param *param)
+{
+	return rswitch_modify_l3fwd(param, false);
+}
+
+static void rswitch_put_pf(struct l3_ipv4_fwd_param *param)
+{
+	int fb_num = rs_read32(param->priv->addr + FWCFMCij(param->pf_cascade_index, 0)) & 0xff;
+	int fb_idx = FBFILTER_IDX(fb_num);
+
+	rs_write32(0, param->priv->addr + FWCFCi(param->pf_cascade_index));
+	rs_write32(0, param->priv->addr + FWFOBFV0Ci(fb_idx));
+	rs_write32(0, param->priv->addr + FWFOBFV1Ci(fb_idx));
+	rs_write32(0, param->priv->addr + FWFOBFCi(fb_idx));
+	rs_write32(0, param->priv->addr + FWCFMCij(param->pf_cascade_index, 0));
+
+	clear_bit(fb_idx, param->priv->filters.four_bytes);
+	clear_bit(param->pf_cascade_index, param->priv->filters.cascade);
+}
+
+static int rswitch_remove_l3fwd(struct l3_ipv4_fwd_param *param)
+{
+	clear_bit(param->l23_info.routing_number, param->priv->l23_routing_number);
+
+	// Using Perfect filter, reset it
+	if (param->frame_type == LTHSLP0NONE)
+		rswitch_put_pf(param);
+
+	return rswitch_modify_l3fwd(param, true);
+}
+
+static int rswitch_add_ipv4_dst_route(struct rswitch_ipv4_route *routing_list, struct rswitch_device *dev, u32 ip)
+{
+	struct rswitch_private *priv = dev->priv;
+	int cascade_idx, four_byte_idx;
+	struct l3_ipv4_fwd_param_list *param_list;
+	int ret = 0;
+
+	cascade_idx = find_first_zero_bit(priv->filters.cascade, PFL_CADF_N);
+	four_byte_idx = find_first_zero_bit(priv->filters.four_bytes, PFL_FOBF_N);
+
+	if (cascade_idx == PFL_CADF_N || four_byte_idx == PFL_FOBF_N)
+		return -1;
+
+	param_list = kzalloc(sizeof(*param_list), GFP_KERNEL);
+	if (!param_list)
+		return -ENOMEM;
+
+	param_list->param = kzalloc(sizeof(struct l3_ipv4_fwd_param), GFP_KERNEL);
+	if (!param_list->param) {
+		ret = -ENOMEM;
+		goto free_param_list;
+	}
+
+	param_list->param->priv = priv;
+	param_list->param->pf_cascade_index = cascade_idx;
+	param_list->param->dv = BIT(priv->gwca.index);
+	param_list->param->slv = 0x3F;
+	param_list->param->csd = dev->rx_default_chain->index;
+	param_list->param->frame_type = LTHSLP0NONE;
+	param_list->param->enable_sub_dst = true;
+	param_list->param->l23_info.priv = priv;
+	param_list->param->l23_info.update_ttl = true;
+	param_list->param->l23_info.update_dst_mac = true;
+	param_list->param->l23_info.routing_port_valid = 0x3F;
+	param_list->param->l23_info.routing_number = rswitch_rn_get(priv);
+	memcpy(param_list->param->l23_info.dst_mac, dev->ndev->dev_addr, ETH_ALEN);
+
+	rs_write32(0, priv->addr + FWCFCi(cascade_idx));
+
+	rs_write32(ip, priv->addr + FWFOBFV0Ci(four_byte_idx));
+	rs_write32(0, priv->addr + FWFOBFV1Ci(four_byte_idx));
+	rs_write32(PRECISE_MODE | SNOOPING_BUS_OFFSET(IPV4_DST_OFFSET), priv->addr + FWFOBFCi(four_byte_idx));
+	rs_write32(FBFILTER_NUM(four_byte_idx) | ENABLE_FILTER, priv->addr + FWCFMCij(cascade_idx, 0));
+
+	rs_write32(0x000f0003f, priv->addr + FWCFCi(cascade_idx));
+
+	set_bit(four_byte_idx, priv->filters.four_bytes);
+	set_bit(cascade_idx, priv->filters.cascade);
+
+	ret = rswitch_add_l3fwd(param_list->param);
+	if (ret)
+		goto free_param;
+
+	list_add(&param_list->list, &routing_list->param_list);
+
+	return ret;
+
+free_param:
+	kfree(param_list->param);
+free_param_list:
+	kfree(param_list);
+	return ret;
+}
+
+static void rswitch_fib_event_add(struct rswitch_fib_event_work *fib_work)
+{
+	struct fib_entry_notifier_info fen;
+	struct rswitch_ipv4_route *new_routing_list;
+	struct rswitch_device *dev;
+	struct fib_nh *nh;
+
+	fen = fib_work->fen_info;
+	nh = fib_info_nh(fen.fi, 0);
+
+	if (fen.type != RTN_UNICAST)
+		return;
+
+	dev = get_dev_by_ip(fib_work->priv, be32_to_cpu(nh->nh_saddr), false);
+	if (!dev)
+		return;
+
+	new_routing_list = kzalloc(sizeof(*new_routing_list), GFP_KERNEL);
+	if (!new_routing_list)
+		return;
+
+	new_routing_list->ip = be32_to_cpu(nh->nh_saddr);
+	new_routing_list->mask = be32_to_cpu(inet_make_mask(fen.dst_len));
+	new_routing_list->subnet = fen.dst;
+	new_routing_list->dev = dev;
+	INIT_LIST_HEAD(&new_routing_list->param_list);
+
+	list_add(&new_routing_list->list, &dev->routing_list);
+
+	if (!rswitch_add_ipv4_dst_route(new_routing_list, dev, be32_to_cpu(nh->nh_saddr)))
+		nh->fib_nh_flags |= RTNH_F_OFFLOAD;
+}
+
+static void rswitch_fib_event_remove(struct rswitch_fib_event_work *fib_work)
+{
+	struct fib_entry_notifier_info fen;
+	struct rswitch_device *dev;
+	struct fib_nh *nh;
+	struct list_head *cur, *tmp;
+	struct rswitch_ipv4_route *routing_list;
+	struct l3_ipv4_fwd_param_list *param_list;
+	bool route_found = false;
+
+	fen = fib_work->fen_info;
+	nh = fib_info_nh(fen.fi, 0);
+
+	if (fen.type != RTN_UNICAST)
+		return;
+
+	dev = get_dev_by_ip(fib_work->priv, be32_to_cpu(nh->nh_saddr), false);
+	if (!dev)
+		return;
+
+	list_for_each(cur, &dev->routing_list) {
+		routing_list = list_entry(cur, struct rswitch_ipv4_route, list);
+		if (routing_list->subnet == fen.dst && routing_list->ip == be32_to_cpu(nh->nh_saddr)) {
+			route_found = true;
+			break;
+		}
+	}
+
+	// There is nothing to free
+	if (!route_found)
+		return;
+
+	list_for_each_safe(cur, tmp, &routing_list->param_list) {
+		param_list = list_entry(cur, struct l3_ipv4_fwd_param_list, list);
+		rswitch_remove_l3fwd(param_list->param);
+		list_del(cur);
+		kfree(param_list->param);
+		kfree(param_list);
+	}
+
+	list_del(&routing_list->list);
+	kfree(routing_list);
+}
+
+static void rswitch_fib_event_work(struct work_struct *work)
+{
+	struct rswitch_fib_event_work *fib_work =
+		container_of(work, struct rswitch_fib_event_work, work);
+
+	/* Protect internal structures from changes */
+	rtnl_lock();
+	switch (fib_work->event) {
+	case FIB_EVENT_ENTRY_REPLACE:
+		rswitch_fib_event_add(fib_work);
+		fib_info_put(fib_work->fen_info.fi);
+		break;
+	case FIB_EVENT_ENTRY_DEL:
+		rswitch_fib_event_remove(fib_work);
+		fib_info_put(fib_work->fen_info.fi);
+		break;
+	}
+
+	rtnl_unlock();
+	kfree(fib_work);
+}
+
+/* Called with rcu_read_lock() */
+static int rswitch_fib_event(struct notifier_block *nb,
+				   unsigned long event, void *ptr)
+{
+	struct rswitch_private *priv = container_of(nb, struct rswitch_private, fib_nb);
+	struct fib_notifier_info *info = ptr;
+	struct rswitch_fib_event_work *fib_work;
+
+	// Handle only IPv4 routes
+	if (info->family != AF_INET)
+		return NOTIFY_DONE;
+
+	fib_work = kzalloc(sizeof(*fib_work), GFP_ATOMIC);
+	if (WARN_ON(!fib_work))
+		return NOTIFY_BAD;
+
+	fib_work->event = event;
+	fib_work->priv = priv;
+
+	INIT_WORK(&fib_work->work, rswitch_fib_event_work);
+
+	switch (event) {
+	case FIB_EVENT_ENTRY_ADD:
+	case FIB_EVENT_ENTRY_APPEND:
+	case FIB_EVENT_ENTRY_DEL:
+	case FIB_EVENT_ENTRY_REPLACE:
+		if (info->family == AF_INET) {
+			struct fib_entry_notifier_info *fen_info = ptr;
+
+			if (fen_info->fi->fib_nh_is_v6) {
+				NL_SET_ERR_MSG_MOD(info->extack, "IPv6 gateway with IPv4 route is not supported");
+				kfree(fib_work);
+				return notifier_from_errno(-EINVAL);
+			}
+			if (fen_info->fi->nh) {
+				NL_SET_ERR_MSG_MOD(info->extack, "IPv4 route with nexthop objects is not supported");
+				kfree(fib_work);
+				return notifier_from_errno(-EINVAL);
+			}
+		}
+
+		memcpy(&fib_work->fen_info, ptr, sizeof(fib_work->fen_info));
+		/* Take referece on fib_info to prevent it from being
+		 * freed while work is queued. Release it afterwards.
+		 */
+		fib_info_hold(fib_work->fen_info.fi);
+		break;
+	}
+
+	queue_work(priv->rswitch_fib_wq, &fib_work->work);
+
+	return NOTIFY_DONE;
+}
+
+static __net_init int rswitch_init_net(struct net *net)
+{
+	struct rswitch_net *rn_init = net_generic(&init_net, rswitch_net_id);
+
+	// Notifier for initial network is already registered
+	if (net == &init_net)
+		return 0;
+
+	rn_init->priv->fib_nb.notifier_call = rswitch_fib_event;
+	return register_fib_notifier(net, &rn_init->priv->fib_nb, NULL, NULL);
+}
+
+static void __net_exit rswitch_exit_net(struct net *net)
+{
+	struct rswitch_net *rn_init = net_generic(&init_net, rswitch_net_id);
+
+	if (net == &init_net)
+		return;
+
+	unregister_fib_notifier(net, &rn_init->priv->fib_nb);
+}
+
+struct pernet_operations rswitch_net_ops = {
+	.init = rswitch_init_net,
+	.exit = rswitch_exit_net,
+	.id   = &rswitch_net_id,
+	.size = sizeof(struct rswitch_net),
 };
 
 static int rswitch_get_ts_info(struct net_device *ndev, struct ethtool_ts_info *info)
@@ -2131,6 +2643,7 @@ static int rswitch_gwca_chain_init(struct net_device *ndev,
 {
 	int i, bit;
 	int index = c->index;	/* Keep the index before memset() */
+	struct device *dev;
 	struct sk_buff *skb;
 
 	memset(c, 0, sizeof(*c));
@@ -2154,16 +2667,23 @@ static int rswitch_gwca_chain_init(struct net_device *ndev,
 		}
 	}
 
+	if (ndev)
+		dev = ndev->dev.parent;
+	else
+		dev = &priv->pdev->dev;
+
 	if (gptp)
-		c->ts_ring = dma_alloc_coherent(ndev->dev.parent,
+		c->ts_ring = dma_alloc_coherent(dev,
 				sizeof(struct rswitch_ext_ts_desc) *
 				(c->num_ring + 1), &c->ring_dma, GFP_KERNEL);
 	else
-		c->ring = dma_alloc_coherent(ndev->dev.parent,
+		c->ring = dma_alloc_coherent(dev,
 				sizeof(struct rswitch_ext_desc) *
 				(c->num_ring + 1), &c->ring_dma, GFP_KERNEL);
-	if (!c->ts_ring && !c->ring)
+	if (!c->ts_ring && !c->ring) {
+		dev_err(dev, "Failed to allocate ring buffer for descriptors\n");
 		goto out;
+	}
 
 	index = c->index / 32;
 	bit = BIT(c->index % 32);
@@ -2186,17 +2706,23 @@ static int rswitch_gwca_chain_format(struct net_device *ndev,
 {
 	struct rswitch_ext_desc *ring;
 	struct rswitch_desc *desc;
+	struct device *dev;
 	int tx_ring_size = sizeof(*ring) * c->num_ring;
 	int i;
 	dma_addr_t dma_addr;
 
+	if (ndev)
+		dev = ndev->dev.parent;
+	else
+		dev = &priv->pdev->dev;
+
 	memset(c->ring, 0, tx_ring_size);
 	for (i = 0, ring = c->ring; i < c->num_ring; i++, ring++) {
 		if (!c->dir_tx) {
-			dma_addr = dma_map_single(ndev->dev.parent,
+			dma_addr = dma_map_single(dev,
 					c->skb[i]->data, PKT_BUF_SZ,
 					DMA_FROM_DEVICE);
-			if (!dma_mapping_error(ndev->dev.parent, dma_addr))
+			if (!dma_mapping_error(dev, dma_addr))
 				ring->info_ds = cpu_to_le16(PKT_BUF_SZ);
 			ring->dptrl = cpu_to_le32(lower_32_bits(dma_addr));
 			ring->dptrh = cpu_to_le32(upper_32_bits(dma_addr));
@@ -2285,7 +2811,6 @@ static void rswitch_desc_free(struct rswitch_private *priv)
 				  priv->desc_bat, priv->desc_bat_dma);
 	priv->desc_bat = NULL;
 }
-
 static struct rswitch_gwca_chain *rswitch_gwca_get(struct rswitch_private *priv)
 {
 	int index;
@@ -2348,26 +2873,42 @@ int rswitch_rxdmac_init(struct net_device *ndev, struct rswitch_private *priv)
 	struct rswitch_device *rdev = netdev_priv(ndev);
 	int err;
 
-	rdev->rx_chain = rswitch_gwca_get(priv);
-	if (!rdev->rx_chain)
+	rdev->rx_default_chain = rswitch_gwca_get(priv);
+	if (!rdev->rx_default_chain)
 		return -EBUSY;
 
-	err = rswitch_gwca_chain_init(ndev, priv, rdev->rx_chain, false, true,
+	rdev->rx_learning_chain = rswitch_gwca_get(priv);
+	if (!rdev->rx_learning_chain)
+		goto put_default;
+
+	err = rswitch_gwca_chain_init(ndev, priv, rdev->rx_default_chain, false, true,
 				      RX_RING_SIZE);
 	if (err < 0)
-		goto out_init;
+		goto put_learning;
 
-	err = rswitch_gwca_chain_ts_format(ndev, priv, rdev->rx_chain);
+	err = rswitch_gwca_chain_init(ndev, priv, rdev->rx_learning_chain, false, true,
+				      RX_RING_SIZE);
 	if (err < 0)
-		goto out_format;
+		goto free_default;
+
+	err = rswitch_gwca_chain_ts_format(ndev, priv, rdev->rx_default_chain);
+	if (err < 0)
+		goto free_learning;
+
+	err = rswitch_gwca_chain_ts_format(ndev, priv, rdev->rx_learning_chain);
+	if (err < 0)
+		goto free_learning;
 
 	return 0;
 
-out_format:
-	rswitch_gwca_chain_free(ndev, priv, rdev->rx_chain);
-
-out_init:
-	rswitch_gwca_put(priv, rdev->rx_chain);
+free_learning:
+	rswitch_gwca_chain_free(ndev, priv, rdev->rx_learning_chain);
+free_default:
+	rswitch_gwca_chain_free(ndev, priv, rdev->rx_default_chain);
+put_learning:
+	rswitch_gwca_put(priv, rdev->rx_learning_chain);
+put_default:
+	rswitch_gwca_put(priv, rdev->rx_default_chain);
 
 	return err;
 }
@@ -2376,8 +2917,10 @@ void rswitch_rxdmac_free(struct net_device *ndev, struct rswitch_private *priv)
 {
 	struct rswitch_device *rdev = netdev_priv(ndev);
 
-	rswitch_gwca_chain_free(ndev, priv, rdev->rx_chain);
-	rswitch_gwca_put(priv, rdev->rx_chain);
+	rswitch_gwca_chain_free(ndev, priv, rdev->rx_default_chain);
+	rswitch_gwca_chain_free(ndev, priv, rdev->rx_learning_chain);
+	rswitch_gwca_put(priv, rdev->rx_default_chain);
+	rswitch_gwca_put(priv, rdev->rx_learning_chain);
 }
 
 static int rswitch_ndev_register(struct rswitch_private *priv, int index)
@@ -2398,6 +2941,7 @@ static int rswitch_ndev_register(struct rswitch_private *priv, int index)
 	rdev = netdev_priv(ndev);
 	rdev->ndev = ndev;
 	rdev->priv = priv;
+	INIT_LIST_HEAD(&rdev->routing_list);
 	priv->rdev[index] = rdev;
 	/* TODO: netdev instance : ETHA port is 1:1 mapping */
 	if (index < RSWITCH_MAX_NUM_ETHA) {
@@ -2431,13 +2975,17 @@ static int rswitch_ndev_register(struct rswitch_private *priv, int index)
 	if (!is_valid_ether_addr(ndev->dev_addr))
 		eth_hw_addr_random(ndev);
 
+	priv->rswitch_fib_wq = alloc_ordered_workqueue("rswitch_ordered", 0);
+	if (!priv->rswitch_fib_wq)
+		return -ENOMEM;
+
 	/* Network device register */
 	err = register_netdev(ndev);
 	if (err)
 		goto out_reg_netdev;
 
 	/* FIXME: it seems S4 VPF has FWPBFCSDC0/1 only so that we cannot set
-	 * CSD = 1 (rx_chain->index = 1) for FWPBFCS03. So, use index = 0
+	 * CSD = 1 (rx_default_chain->index = 1) for FWPBFCS03. So, use index = 0
 	 * for the RX.
 	 */
 	err = rswitch_rxdmac_init(ndev, priv);
@@ -2496,7 +3044,8 @@ static void rswitch_queue_interrupt(struct net_device *ndev)
 
 	if (napi_schedule_prep(&rdev->napi)) {
 		rswitch_enadis_data_irq(rdev->priv, rdev->tx_chain->index, false);
-		rswitch_enadis_data_irq(rdev->priv, rdev->rx_chain->index, false);
+		rswitch_enadis_data_irq(rdev->priv, rdev->rx_default_chain->index, false);
+		rswitch_enadis_data_irq(rdev->priv, rdev->rx_learning_chain->index, false);
 		__napi_schedule(&rdev->napi);
 	}
 }
@@ -2511,7 +3060,7 @@ static irqreturn_t __maybe_unused rswitch_data_irq(struct rswitch_private *priv,
 		c = &priv->gwca.chains[i];
 		index = c->index / 32;
 		bit = BIT(c->index % 32);
-		if (!(dis[index] & bit) || !(test_bit(i , priv->gwca.used)))
+		if (!(dis[index] & bit) || !(test_bit(i, priv->gwca.used)))
 			continue;
 
 		rswitch_ack_data_irq(priv, c->index);
@@ -2566,6 +3115,136 @@ static int rswitch_free_irqs(struct rswitch_private *priv)
 	return 0;
 }
 
+static int rswitch_ipv4_resolve(struct rswitch_device *rdev, u32 ip, u8 mac[ETH_ALEN])
+{
+	__be32 be_ip = cpu_to_be32(ip);
+	struct net_device *ndev = rdev->ndev;
+	struct neighbour *neigh = neigh_lookup(&arp_tbl, &be_ip, ndev);
+	int err = 0;
+
+	if (!neigh) {
+		neigh = neigh_create(&arp_tbl, &be_ip, ndev);
+		if (IS_ERR(neigh))
+			return PTR_ERR(neigh);
+	}
+
+	neigh_event_send(neigh, NULL);
+
+	read_lock_bh(&neigh->lock);
+	if ((neigh->nud_state & NUD_VALID) && !neigh->dead)
+		memcpy(mac, neigh->ha, ETH_ALEN);
+	else
+		err = -ENOENT;
+	read_unlock_bh(&neigh->lock);
+
+	neigh_release(neigh);
+
+	return err;
+}
+
+void rswitch_add_ipv4_forward_all_types(struct l3_ipv4_fwd_param *param, struct rswitch_ipv4_route *routing_list)
+{
+	struct l3_ipv4_fwd_param_list *param_list;
+	const int frame_type_num = 3;
+	int i, j;
+
+	param_list = kcalloc(frame_type_num, sizeof(*param_list), GFP_KERNEL);
+	if (!param_list)
+		return;
+
+	for (i = 0; i < frame_type_num; i++) {
+		param_list[i].param = kcalloc(frame_type_num, sizeof(*param), GFP_KERNEL);
+		if (!param_list[i].param) {
+			goto free;
+		}
+		memcpy(param_list[i].param, param, sizeof(*param));
+	}
+
+	param_list[0].param->frame_type = LTHSLP0v4OTHER;
+	if (rswitch_add_l3fwd(param_list[0].param))
+		goto free;
+
+	param_list[1].param->frame_type = LTHSLP0v4UDP;
+	if (rswitch_add_l3fwd(param_list[1].param)) {
+		rswitch_remove_l3fwd(param_list[0].param);
+		goto free;
+	}
+
+	param_list[2].param->frame_type = LTHSLP0v4TCP;
+	if (rswitch_add_l3fwd(param_list[2].param)) {
+		rswitch_remove_l3fwd(param_list[0].param);
+		rswitch_remove_l3fwd(param_list[1].param);
+		goto free;
+	}
+
+	list_add(&param_list[0].list, &routing_list->param_list);
+	list_add(&param_list[1].list, &routing_list->param_list);
+	list_add(&param_list[2].list, &routing_list->param_list);
+
+	return;
+
+free:
+	for (j = 0; j < i; j++)
+		kfree(param_list[j].param);
+
+	kfree(param_list);
+}
+
+static struct rswitch_ipv4_route *rswitch_get_route(struct rswitch_private *priv, u32 dst_ip)
+{
+	struct rswitch_ipv4_route *routing_list;
+	struct list_head *cur;
+	int i;
+
+	for (i = 0; i < RSWITCH_NUM_HW; i++) {
+		list_for_each(cur, &priv->rdev[i]->routing_list) {
+			routing_list = list_entry(cur, struct rswitch_ipv4_route, list);
+			if (routing_list->subnet == (dst_ip & routing_list->mask)) {
+				return routing_list;
+			}
+		}
+	}
+
+	return NULL;
+}
+
+void rswitch_add_ipv4_forward(struct rswitch_private *priv, u32 src_ip, u32 dst_ip)
+{
+	struct rswitch_device *dev;
+	struct rswitch_ipv4_route *routing_list = NULL;
+	struct l3_ipv4_fwd_param param;
+	u8 mac[ETH_ALEN];
+
+	if (is_l3_exist(priv, src_ip, dst_ip))
+		return;
+
+	routing_list = rswitch_get_route(priv, dst_ip);
+	if (!routing_list)
+		return;
+
+	dev = routing_list->dev;
+	if (rswitch_ipv4_resolve(dev, dst_ip, mac))
+		return;
+
+	param.dv = BIT(dev->port);
+	param.csd = 0;
+	param.enable_sub_dst = false;
+	memcpy(param.l23_info.dst_mac, mac, ETH_ALEN);
+	param.slv = 0x3F;
+	param.l23_info.priv = priv;
+	param.l23_info.update_ttl = true;
+	param.l23_info.update_dst_mac = true;
+	param.l23_info.update_src_mac = false;
+	param.l23_info.routing_port_valid = 0x3F;
+	param.l23_info.routing_number = rswitch_rn_get(priv);
+
+	param.priv = priv;
+	param.src_ip = src_ip;
+	param.dst_ip = dst_ip;
+
+	rswitch_add_ipv4_forward_all_types(&param, routing_list);
+}
+
 static void rswitch_fwd_init(struct rswitch_private *priv)
 {
 	int i;
@@ -2580,14 +3259,33 @@ static void rswitch_fwd_init(struct rswitch_private *priv)
 	 * Currently, always forward to GWCA0.
 	 */
 	for (i = 0; i < num_ndev; i++) {
-		rs_write32(priv->rdev[i]->rx_chain->index, priv->addr + FWPBFCSDC(0, i));
+		rs_write32(priv->rdev[i]->rx_learning_chain->index, priv->addr + FWPBFCSDC(0, i));
 		rs_write32(8, priv->addr + FWPBFC(i));
 	}
 	rs_write32(0x07, priv->addr + FWPBFC(3));
 
-
 	/* Enable Direct Descriptors for GWCA0 */
 	rs_write32(FWPC1_DDE, priv->addr + FWPC10 + (3 * 0x10));
+	/* Set L3 hash maximum unsecure entry to 512 */
+	rs_write32(0x200 << 16, priv->addr + FWLTHHEC);
+	/* Disable hash equation */
+	rs_write32(0, priv->addr + FWSFHEC);
+	/* Enable access from unsecure APB for the first 32 update rules */
+	rs_write32(0xffffffff, priv->addr + FWSCR34);
+	/* Enable access from unsecure APB for the first 32 four-byte filters */
+	rs_write32(0xffffffff, priv->addr + FWSCR12);
+	/* Enable access from unsecure APB for the first 32 cascade filters */
+	rs_write32(0xffffffff, priv->addr + FWSCR20);
+	/* Init parameters for IPv4/v6 hash extract */
+	rs_write32(BIT(22) | BIT(23), priv->addr + FWIP4SC);
+	/* Reset L3 table */
+	rs_write32(LTHTIOG, priv->addr + FWLTHTIM);
+	//TODO: Check result
+	rswitch_reg_wait(priv->addr, FWLTHTIM, LTHTR, 1);
+	/* Reset L2/3 update table */
+	rs_write32(LTHTIOG, priv->addr + FWL23UTIM);
+	//TODO: Check result
+	rswitch_reg_wait(priv->addr, FWL23UTIM, BIT(1), 1);
 	/* TODO: add chrdev for fwd */
 	/* TODO: add proc for fwd */
 }
@@ -2643,26 +3341,6 @@ out:
 	return err;
 }
 
-/* Called with rcu_read_lock() */
-static int rswitch_fib_event(struct notifier_block *nb,
-				   unsigned long event, void *ptr)
-{
-	struct fib_notifier_info *info = ptr;
-	//struct fib_entry_notifier_info *fen_info = ptr;
-	pr_err("%s %d event = 0x%lx, family = 0x%x\n", __func__, __LINE__, event, info->family);
-
-	switch (event) {
-	case FIB_EVENT_RULE_ADD:
-	case FIB_EVENT_RULE_DEL:
-	case FIB_EVENT_ENTRY_ADD:
-	case FIB_EVENT_ENTRY_REPLACE:
-	case FIB_EVENT_ENTRY_APPEND:
-		break;
-	}
-
-	return NOTIFY_DONE;
-}
-
 static void rswitch_deinit_rdev(struct rswitch_private *priv, int index)
 {
 	struct rswitch_device *rdev = priv->rdev[index];
@@ -2690,6 +3368,7 @@ static int renesas_eth_sw_probe(struct platform_device *pdev)
 {
 	struct rswitch_private *priv;
 	struct resource *res, *res_serdes;
+	struct rswitch_net *rn;
 	int ret;
 
 	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
@@ -2743,7 +3422,7 @@ static int renesas_eth_sw_probe(struct platform_device *pdev)
 	/* Fixed to use GWCA0 */
 	priv->gwca.index = 3;
 	priv->gwca.num_chains = num_ndev * NUM_CHAINS_PER_NDEV +
-		num_virt_devices * 2 * NUM_CHAINS_PER_NDEV;
+		num_virt_devices * 2 * NUM_CHAINS_PER_NDEV + 2;
 	priv->gwca.chains = devm_kcalloc(&pdev->dev, priv->gwca.num_chains,
 					 sizeof(*priv->gwca.chains), GFP_KERNEL);
 	if (!priv->gwca.chains)
@@ -2762,15 +3441,14 @@ static int renesas_eth_sw_probe(struct platform_device *pdev)
 
 	device_set_wakeup_capable(&pdev->dev, 1);
 
-	priv->fib_nb.notifier_call = rswitch_fib_event;
-	ret = register_fib_notifier(&init_net, &priv->fib_nb, NULL, NULL);
-	if (ret) {
-		pr_err("%s %d error = %d\n", __func__, __LINE__, ret);
-	} else {
-		pr_err("%s %d SUCCESS\n", __func__, __LINE__);
-	}
+	register_pernet_subsys(&rswitch_net_ops);
+ 
+	rn = net_generic(&init_net, rswitch_net_id);
+	rn->priv = priv;
 
-	return 0;
+	priv->fib_nb.notifier_call = rswitch_fib_event;
+
+	return register_fib_notifier(&init_net, &priv->fib_nb, NULL, NULL);
 }
 
 static int renesas_eth_sw_remove(struct platform_device *pdev)
@@ -2788,6 +3466,7 @@ static int renesas_eth_sw_remove(struct platform_device *pdev)
 	rswitch_desc_free(priv);
 
 	platform_set_drvdata(pdev, NULL);
+	unregister_fib_notifier(&init_net, &priv->fib_nb);
 
 	return 0;
 }

--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -9,6 +9,21 @@
 #include <linux/phy.h>
 #include <linux/netdevice.h>
 #include <linux/io.h>
+#include <linux/list.h>
+#include <net/fib_rules.h>
+#include <net/fib_notifier.h>
+#include <net/ip_fib.h>
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/proc_fs.h>
+#include <linux/workqueue.h>
+#include <linux/sched.h>
+#include <linux/init.h>
+#include <linux/interrupt.h>
+#include <linux/inetdevice.h>
+#include <net/devlink.h>
+#include <net/net_namespace.h>
 
 static inline u32 rs_read32(void *addr)
 {
@@ -127,6 +142,7 @@ struct rswitch_gwca_chain {
 #define RSWITCH_NUM_HW		5
 #define RSWITCH_MAX_NUM_ETHA	3
 #define RSWITCH_MAX_NUM_NDEV	8
+#define RSWITCH_MAX_NUM_L23 (256)
 
 #define TX_RING_SIZE		1024
 #define RX_RING_SIZE		1024
@@ -167,6 +183,48 @@ struct rswitch_mfwd {
 	int num_mac_table_entries;
 };
 
+struct l23_update_info {
+	struct rswitch_private *priv;
+	u8 dst_mac[ETH_ALEN];
+	u32 routing_port_valid;
+	u32 routing_number;
+	bool update_ttl;
+	bool update_dst_mac;
+	bool update_src_mac;
+};
+
+struct l3_ipv4_fwd_param {
+	struct rswitch_private *priv;
+	struct l23_update_info l23_info;
+	u32 src_ip;
+	union {
+		u32 dst_ip;
+		u32 pf_cascade_index;
+	};
+	// CPU sub destination
+	u32 csd;
+	// Destination vector
+	u32 dv;
+	// Source lock vector
+	u32 slv;
+	u8 frame_type;
+	bool enable_sub_dst;
+};
+
+struct l3_ipv4_fwd_param_list {
+	struct l3_ipv4_fwd_param *param;
+	struct list_head list;
+};
+
+struct rswitch_ipv4_route {
+	u32 ip;
+	u32 subnet;
+	u32 mask;
+	struct rswitch_device *dev;
+	struct list_head param_list;
+	struct list_head list;
+};
+
 struct rswitch_device {
 	struct rswitch_private *priv;
 	struct net_device *ndev;
@@ -174,13 +232,34 @@ struct rswitch_device {
 	void __iomem *addr;
 	bool gptp_master;
 	struct rswitch_gwca_chain *tx_chain;
-	struct rswitch_gwca_chain *rx_chain;
+	struct rswitch_gwca_chain *rx_default_chain;
+	struct rswitch_gwca_chain *rx_learning_chain;
 	spinlock_t lock;
 	u8 ts_tag;
 
 	int port;
 	struct rswitch_etha *etha;
 	int remote_chain;
+	struct list_head routing_list;
+};
+
+// Two-byte filter number
+#define PFL_TWBF_N (48)
+// Three-byte filter number
+#define PFL_THBF_N (16)
+// Four-byte filter number
+#define PFL_FOBF_N (48)
+// Range-byte filter number
+#define PFL_RAGF_N (16)
+// Cascade filter number
+#define PFL_CADF_N (64)
+
+struct rswitch_filters {
+	DECLARE_BITMAP(two_bytes, PFL_TWBF_N);
+	DECLARE_BITMAP(three_bytes, PFL_THBF_N);
+	DECLARE_BITMAP(four_bytes, PFL_FOBF_N);
+	DECLARE_BITMAP(range_byte, PFL_RAGF_N);
+	DECLARE_BITMAP(cascade, PFL_CADF_N);
 };
 
 struct rswitch_private {
@@ -192,19 +271,35 @@ struct rswitch_private {
 	dma_addr_t desc_bat_dma;
 	u32 desc_bat_size;
 	phys_addr_t dev_id;
-	struct notifier_block fib_nb;
 
 	struct rswitch_device *rdev[RSWITCH_MAX_NUM_NDEV];
 
 	struct rswitch_gwca gwca;
 	struct rswitch_etha etha[RSWITCH_MAX_NUM_ETHA];
 	struct rswitch_mfwd mfwd;
+	struct rswitch_filters filters;
 
 	struct clk *rsw_clk;
 	struct clk *phy_clk;
+
+	struct notifier_block fib_nb;
+	struct workqueue_struct *rswitch_fib_wq;
+	DECLARE_BITMAP(l23_routing_number, RSWITCH_MAX_NUM_L23);
 };
 
+struct rswitch_fib_event_work {
+	struct work_struct work;
+	union {
+		struct fib_entry_notifier_info fen_info;
+		struct fib_rule_notifier_info fr_info;
+	};
+	struct rswitch_private *priv;
+	unsigned long event;
+};
+
+extern struct pernet_operations rswitch_net_ops;
 extern const struct net_device_ops rswitch_netdev_ops;
+extern const struct devlink_ops rswitch_dl_ops;
 
 int rswitch_txdmac_init(struct net_device *ndev, struct rswitch_private *priv);
 void rswitch_txdmac_free(struct net_device *ndev, struct rswitch_private *priv);
@@ -217,3 +312,5 @@ int rswitch_poll(struct napi_struct *napi, int budget);
 int rswitch_xen_ndev_register(struct rswitch_private *priv, int index);
 int rswitch_xen_connect_devs(struct rswitch_device *rdev1,
 			     struct rswitch_device *rdev2);
+
+void rswitch_add_ipv4_forward(struct rswitch_private *priv, u32 src_ip, u32 dst_ip);

--- a/drivers/net/ethernet/renesas/rswitch_xen.c
+++ b/drivers/net/ethernet/renesas/rswitch_xen.c
@@ -26,6 +26,7 @@ int rswitch_xen_ndev_register(struct rswitch_private *priv, int index)
 	rdev = netdev_priv(ndev);
 	rdev->ndev = ndev;
 	rdev->priv = priv;
+	INIT_LIST_HEAD(&rdev->routing_list);
 	/* TODO: Fix index calculation */
 	priv->rdev[index + 3] = rdev;
 	rdev->port = 3; 	/* TODO: This is supposed to be GWCA0 port */
@@ -81,8 +82,8 @@ out_reg_netdev:
 int rswitch_xen_connect_devs(struct rswitch_device *rdev1,
 			     struct rswitch_device *rdev2)
 {
-	rdev1->remote_chain = rdev2->rx_chain->index;
-	rdev2->remote_chain = rdev1->rx_chain->index;
+	rdev1->remote_chain = rdev2->rx_learning_chain->index;
+	rdev2->remote_chain = rdev1->rx_learning_chain->index;
 
 	return 0;
 }


### PR DESCRIPTION
L3 offload requires implementing FIB notifier for switch device, which
is responsible for handling FIB events and rule changes. The notifier
callback is invoked when interface initializes, or some new IP route
adds. In this case, the notifier should handle add/delete route and
make appropriate configuration on HW side. The L3 HW offload on
S4 R-Switch is implemented using MFWD L3 routing, perfect filters,
and L23 update table. When the IP routing callback is invoked, it adds
a new route via Perfect filters to the existing interface and caches
information about which packets can be routed using this interface.
When packets go from R-Switch to outside they firstly come to
rx_learning_chain, where they will be analyzed, and if match with
cached before routing rules, the appropriate L3 rule will be added
via L3 IPv4/v6 hash extract. After that, packets that match this
stream ID will be forwarded to the appropriate destination port with
updating destination MAC and TTL via L23 Update logic.

Testing setup:
For board:
ip netns add linuxhint
ip link set vmq0 netns linuxhint
ip netns exec linuxhint ifconfig vmq0 up
ip netns exec linuxhint ifconfig vmq0 192.168.2.2
ifconfig vmq1 up
ifconfig vmq1 192.168.2.1
ip netns exec linuxhint ip route add 192.168.1.0/24 via 192.168.2.1
[TSN0 IP 192.168.1.1]

For Host:
sudo ip route add 192.168.2.0/24 via 192.168.1.1
[Host IP 192.168.1.100]

Signed-off-by: Leonid Komarianskyi <leonid_komarianskyi@epam.com>