### PR TITLE
Several fixes for R-Switch driver

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -2021,6 +2021,9 @@ static struct rswitch_device *get_dev_by_ip(struct rswitch_private *priv, u32 ip
 	int i;
 
 	for (i = 0; i < RSWITCH_NUM_HW; i++) {
+		if (!priv->rdev[i])
+			break;
+
 		ip = priv->rdev[i]->ndev->ip_ptr;
 		if (ip == NULL)
 			continue;

--- a/drivers/net/ethernet/renesas/rswitch.h
+++ b/drivers/net/ethernet/renesas/rswitch.h
@@ -5,6 +5,9 @@
  * Copyright (C) 2022 EPAM Systems
  */
 
+#ifndef __RSWITCH_H__
+#define __RSWITCH_H__
+
 #include <linux/kernel.h>
 #include <linux/phy.h>
 #include <linux/netdevice.h>
@@ -294,3 +297,5 @@ int rswitch_remove_l3fwd(struct l3_ipv4_fwd_param *param);
 void rswitch_put_pf(struct l3_ipv4_fwd_param *param);
 int rswitch_setup_pf(struct rswitch_pf_param *pf_param);
 int rswitch_rn_get(struct rswitch_private *priv);
+
+#endif /* __RSWITCH_H__ */

--- a/drivers/net/ethernet/renesas/rswitch_tc_filters.h
+++ b/drivers/net/ethernet/renesas/rswitch_tc_filters.h
@@ -5,6 +5,9 @@
  * Copyright (C) 2022 EPAM Systems
  */
 
+#ifndef __RSWITCH_TC_FILTERS_H__
+#define __RSWITCH_TC_FILTERS_H__
+
 #include <linux/netdevice.h>
 #include <net/pkt_cls.h>
 #include <net/flow_offload.h>
@@ -47,3 +50,4 @@ int rswitch_setup_tc_cls_u32(struct net_device *dev,
 int rswitch_setup_tc_matchall(struct net_device *dev,
 				  struct tc_cls_matchall_offload *cls_matchall);
 
+#endif /* __RSWITCH_TC_FILTERS_H__ */

--- a/drivers/net/ethernet/renesas/rswitch_tc_flower.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_flower.c
@@ -12,10 +12,6 @@ static int rswitch_tc_flower_validate_match(struct flow_rule *rule)
 {
 	struct flow_dissector *dissector = rule->match.dissector;
 
-	/*
-	 * Note: IPV6 dissector is always set for IPV4 rules for some reason,
-	 * but true IPV6 rules are not currently supported for offload.
-	 */
 	if (dissector->used_keys &
 		~(BIT(FLOW_DISSECTOR_KEY_CONTROL) |
 		  BIT(FLOW_DISSECTOR_KEY_BASIC) |
@@ -26,6 +22,18 @@ static int rswitch_tc_flower_validate_match(struct flow_rule *rule)
 		  BIT(FLOW_DISSECTOR_KEY_ETH_ADDRS)
 		  )
 	    ) {
+		return -EOPNOTSUPP;
+	}
+
+	/*
+	 * Note: IPV6 dissector is always set for IPV4 rules for some reason,
+	 * but true IPV6 rules are not currently supported for offload.
+	 */
+	if (dissector->used_keys &
+	    ((BIT(FLOW_DISSECTOR_KEY_IPV4_ADDRS) |
+	     BIT(FLOW_DISSECTOR_KEY_IPV6_ADDRS)) ==
+	     BIT(FLOW_DISSECTOR_KEY_IPV6_ADDRS))
+	   ) {
 		return -EOPNOTSUPP;
 	}
 


### PR DESCRIPTION
- Add fixes for flower match rules validation and R-Switch related headers.
- Re-work R-Switch perfect filter initialization with helper functions to reduce boilerplate.