### PR TITLE
drivers: net: renesas: Return error when processing unsupported actions

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch_tc_matchall.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_matchall.c
@@ -138,8 +138,10 @@ static int rswitch_tc_matchall_replace(struct net_device *ndev,
 		}
 
 		/* Drop in hardware */
-		if (entry->id == FLOW_ACTION_DROP)
+		if (entry->id == FLOW_ACTION_DROP) {
 			filter.action |= ACTION_DROP;
+			continue;
+		}
 
 		if (entry->id == FLOW_ACTION_VLAN_MANGLE) {
 			if (be16_to_cpu(entry->vlan.proto) != ETH_P_8021Q) {
@@ -150,7 +152,10 @@ static int rswitch_tc_matchall_replace(struct net_device *ndev,
 			filter.vlan_id = entry->vlan.vid;
 			filter.vlan_prio = entry->vlan.prio;
 			filter.action |= ACTION_VLAN_CHANGE;
+			continue;
 		}
+
+		return -EOPNOTSUPP;
 	}
 
 	/* skbmod cannot be offloaded without redirect */

--- a/drivers/net/ethernet/renesas/rswitch_tc_u32.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_u32.c
@@ -204,8 +204,12 @@ static int rswitch_add_knode(struct net_device *ndev, struct tc_cls_u32_offload 
 		}
 
 		/* Drop in hardware */
-		if (is_tcf_gact_shot(a))
+		if (is_tcf_gact_shot(a)) {
 			filter.action |= ACTION_DROP;
+			continue;
+		}
+
+		return -EOPNOTSUPP;
 	}
 
 	/* skbmod cannot be offloaded without redirect */


### PR DESCRIPTION
At the current state of flower and u32 filter they will accept any number of unsupported action when atleast one supported action is amongst them. Fix this by returning EOPNOTSUPP when we can't match action to any of the supported ones.

Signed-off-by: Mykyta Poturai <mykyta_poturai@epam.com>