### PR TITLE
Fix issue with source lock vector

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch_tc_common.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_common.c
@@ -96,7 +96,7 @@ static int rswitch_tc_setup_redirect_action(struct rswitch_tc_filter *f)
 }
 static int rswitch_tc_setup_drop_action(struct rswitch_tc_filter *f)
 {
-	f->param.slv = 0x3F;
+	f->param.slv = BIT(f->rdev->port);
 	/* Explicitly zeroing parameters for drop */
 	f->param.dv = 0;
 	f->param.csd = 0;

--- a/drivers/net/ethernet/renesas/rswitch_tc_u32.c
+++ b/drivers/net/ethernet/renesas/rswitch_tc_u32.c
@@ -18,7 +18,7 @@ static void rswitch_init_u32_drop_action(struct rswitch_tc_filter *cfg,
 {
 	cfg->action = ACTION_DROP;
 	/* Leave other paramters as zero */
-	cfg->param.slv = 0x3F;
+	cfg->param.slv = BIT(f->rdev->port);
 }
 
 static void rswitch_init_u32_redirect_action(struct rswitch_tc_filter *cfg,


### PR DESCRIPTION
This commit removes issue with SLV value, that defines traffic sources for TC drop action. Previously, it was applied to traffic from all sources (all TSNx and GWCAx). Now it is set only for device, that was specified by traffic control rule.

Signed-off-by: Dmytro Firsov <dmytro_firsov@epam.com>