### PR TITLE
net: renesas: rswitch: add support for 802.1ad offload for flower filter

### DIFF
--- a/drivers/net/ethernet/renesas/rswitch.c
+++ b/drivers/net/ethernet/renesas/rswitch.c
@@ -3609,8 +3609,8 @@ static void rswitch_fwd_init(struct rswitch_private *priv)
 	/* Enable unsecure APB access to VLAN configuration via FWGC and FWTTCi */
 	rs_write32(BIT(0) | BIT(1), priv->addr + FWSCR0);
 
-	/* Enable C-Tag filtering mode for VLANs */
-	rs_write32(BIT(0), priv->addr + FWGC);
+	/* Enable SC-Tag filtering mode for VLANs */
+	rs_write32(BIT(1), priv->addr + FWGC);
 }
 
 static int rswitch_init(struct rswitch_private *priv)


### PR DESCRIPTION
This commit adds implementation of S-tag filtering for flower traffic control filter. It allows to offload 802.1ad match rules to R-Switch hardware.